### PR TITLE
Project and Code Fixes

### DIFF
--- a/RPS.UI/RPS.UI.csproj
+++ b/RPS.UI/RPS.UI.csproj
@@ -3,8 +3,6 @@
 	<PropertyGroup>
 		<TargetFrameworks>net7.0-android;net7.0-ios;net7.0-maccatalyst</TargetFrameworks>
 		<TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('windows'))">$(TargetFrameworks);net7.0-windows10.0.19041.0</TargetFrameworks>
-		<!-- Uncomment to also build the tizen app. You will need to install tizen by following this: https://github.com/Samsung/Tizen.NET -->
-		<!-- <TargetFrameworks>$(TargetFrameworks);net7.0-tizen</TargetFrameworks> -->
 		<OutputType>Exe</OutputType>
 		<RootNamespace>RPS.UI</RootNamespace>
 		<UseMaui>true</UseMaui>
@@ -27,7 +25,6 @@
 		<SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'android'">21.0</SupportedOSPlatformVersion>
 		<SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'windows'">10.0.17763.0</SupportedOSPlatformVersion>
 		<TargetPlatformMinVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'windows'">10.0.17763.0</TargetPlatformMinVersion>
-		<SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'tizen'">6.5</SupportedOSPlatformVersion>
 	</PropertyGroup>
 
 	<ItemGroup>
@@ -49,63 +46,10 @@
 	</ItemGroup>
 
 	<ItemGroup>
-	  <None Remove="BL\GenData\fs-items.json" />
-	  <None Remove="BL\GenData\fs-users.json" />
-	</ItemGroup>
-
-	<ItemGroup>
-	  <Resource Include="Resources\Raw\fs-items.json" />
-	  <Resource Include="Resources\Raw\fs-users.json" />
-	</ItemGroup>
-
-	<ItemGroup>
 		<PackageReference Include="CommunityToolkit.Maui" Version="5.1.0" />
 		<PackageReference Include="CommunityToolkit.Mvvm" Version="8.2.0" />
 		<PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="7.0.0" />
 		<PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
 	</ItemGroup>
-
-	<ItemGroup>
-	  <Compile Update="Views\FlyoutMenuPage.xaml.cs">
-	    <DependentUpon>FlyoutMenuPage.xaml</DependentUpon>
-	  </Compile>
-	</ItemGroup>
-
-	<ItemGroup>
-	  <MauiXaml Update="Views\Backlog\BacklogPage.xaml">
-	    <Generator>MSBuild:Compile</Generator>
-	  </MauiXaml>
-	  <MauiXaml Update="Views\Backlog\DetailsPage.xaml">
-	    <Generator>MSBuild:Compile</Generator>
-	  </MauiXaml>
-	  <MauiXaml Update="Views\Backlog\DetailsView.xaml">
-	    <Generator>MSBuild:Compile</Generator>
-	  </MauiXaml>
-	  <MauiXaml Update="Views\Backlog\ItemsView.xaml">
-	    <Generator>MSBuild:Compile</Generator>
-	  </MauiXaml>
-	  <MauiXaml Update="Views\Backlog\Popups\AddItemPopup.xaml">
-	    <Generator>MSBuild:Compile</Generator>
-	  </MauiXaml>
-	  <MauiXaml Update="Views\Backlog\TasksView.xaml">
-	    <Generator>MSBuild:Compile</Generator>
-	  </MauiXaml>
-	  <MauiXaml Update="Views\Dashboard\DashboardPage.xaml">
-	    <Generator>MSBuild:Compile</Generator>
-	  </MauiXaml>
-	  <MauiXaml Update="Views\FlyoutMenuPage.xaml">
-	    <Generator>MSBuild:Compile</Generator>
-	  </MauiXaml>
-	  <MauiXaml Update="Views\RPSFlyoutPage.xaml">
-	    <Generator>MSBuild:Compile</Generator>
-	  </MauiXaml>
-	  <MauiXaml Update="Views\WelcomePage.xaml">
-	    <Generator>MSBuild:Compile</Generator>
-	  </MauiXaml>
-	</ItemGroup>
-
-	<ItemGroup>
-	  <Folder Include="BL\GenData\" />
-	</ItemGroup>
-
+	
 </Project>

--- a/RPS.UI/Views/Backlog/TasksView.xaml.cs
+++ b/RPS.UI/Views/Backlog/TasksView.xaml.cs
@@ -16,11 +16,12 @@ public partial class TasksView : ContentView
     {
         var curApp = App.Current;
         var mp = curApp.MainPage;
+
         string action = await mp.DisplayActionSheet("Task Action", "Cancel", "null", "Delete", "Complete");
 
         var vm = (TasksScreenViewModel)BindingContext;
 
-        if (action.Equals("Delete"))
+        if(action != null && action.Equals("Delete"))
         {
             vm.DeleteSelectedTask();
         }

--- a/RPSTrackerMAUI.sln
+++ b/RPSTrackerMAUI.sln
@@ -3,7 +3,7 @@ Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio Version 17
 VisualStudioVersion = 17.5.33530.505
 MinimumVisualStudioVersion = 10.0.40219.1
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "RPS.UI", "RPS.UI\RPS.UI.csproj", "{10D28D33-5ED6-4A50-88ED-96F174747049}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "RPS.UI", "RPS.UI\RPS.UI.csproj", "{10D28D33-5ED6-4A50-88ED-96F174747049}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution


### PR DESCRIPTION
- There was some corruption in the solution file that prevented the windows project from being deployable (now works with VS2022 17.7).
- Cleaned up auto-generated, unnecessary, csproj items that overcomplicate demo
- Fixed bug that crashes the app when you select a backlog item's task and dismiss the popup without clicking a button